### PR TITLE
Improve Error handling when worksheet is nil and CompatibilityError.

### DIFF
--- a/lib/embulk/input/googlespreadsheet/error.rb
+++ b/lib/embulk/input/googlespreadsheet/error.rb
@@ -26,7 +26,7 @@ module Embulk
         include Traceable
       end
 
-      class CompatibilityError < DataError; end
+      class UnmatchedNumberOfColomnsError < DataError; end
       class TypeCastError      < DataError; end
       class UnknownTypeError   < DataError; end
     end

--- a/lib/embulk/input/googlespreadsheet/gss_session.rb
+++ b/lib/embulk/input/googlespreadsheet/gss_session.rb
@@ -72,10 +72,7 @@ module Embulk
 
           begin
             ws = session.spreadsheet_by_key(@gss_key).worksheet_by_title(@ws_title)
-            if ws.nil?
-              Embulk.logger.info { "embulk-input-googlespreadsheet: target worksheet does not exist." }
-              return
-            end
+            raise ConfigError.new("target worksheet `#{@ws_title}` does not exist.") unless ws
 
             if end_row == -1
               (start_row..ws.num_rows + 1).each do |row|

--- a/lib/embulk/input/googlespreadsheet/type_converter.rb
+++ b/lib/embulk/input/googlespreadsheet/type_converter.rb
@@ -14,7 +14,7 @@ module Embulk
         def convert(columns, values)
           results = Array.new
           if columns.length != values.length
-            raise CompatibilityError.new("Columns defined and data fetched are imcompatible.")
+            raise UnmatchedNumberOfColomnsError.new("Number of defined Columns and fetched data are unmatched.")
           end
 
           (0...columns.length).each do |index|


### PR DESCRIPTION
@apollocarlos I changed error handling with incompatibility. Could you review and merge this?

and see also https://github.com/apollocarlos/embulk-input-googlespreadsheet/pull/1#issuecomment-284753119