### PR TITLE
Support value_render_option option

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Embulk input plugin to load records from Google Spreadsheets.
 | end_row            | integer     | optional    | `-1`            | `-1` means loading records until an empty record appears. |
 | max_fetch_rows     | integer     | optional    | `10000`        |  Load data from a worksheet for each numerical value specified by this option. |
 | null_string        | string      | optional    | `''`            |  Replace this value to `NULL` |
+| value_render_option| string      | optional    | `'FORMATTED_VALUE'`| `'FORMATTED_VALUE'`, `'UNFORMATTED_VALUE'`, `'FORMULA'` are available. See [the `value_render_option` document](https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption).|
 | stop_on_invalid_record | boolean | optional    | `true`          |  |
 | default_timestamp_format | string | optional | `'%Y-%m-%d %H:%M:%S.%N %z'` | |
 | default_timezone | string | optional | `'UTC'` | |

--- a/example/config_authorized_user_unformatted_value.yml
+++ b/example/config_authorized_user_unformatted_value.yml
@@ -1,0 +1,15 @@
+in:
+  type: google_spreadsheets
+  auth_method: authorized_user
+  json_keyfile: example/authorized_user_credentials.json
+  spreadsheets_url: https://docs.google.com/spreadsheets/d/1Cxz-LudQuhRAGZL8mBoHs6mRnpjODpyF4Rwc5UYoV1E/edit#gid=0
+  worksheet_title: UNFORMATTED VALUE
+  start_row: 2
+  default_timezone: Asia/Tokyo
+  null_string: '\N'
+  default_typecast: strict
+  value_render_option: UNFORMATTED_VALUE
+  columns:
+    - {name: _c1, type: long}
+out:
+  type: stdout

--- a/example/config_service_account_unformatted_value.yml
+++ b/example/config_service_account_unformatted_value.yml
@@ -1,0 +1,15 @@
+in:
+  type: google_spreadsheets
+  auth_method: service_account
+  json_keyfile: example/service_account_credentials.json
+  spreadsheets_url: https://docs.google.com/spreadsheets/d/1Cxz-LudQuhRAGZL8mBoHs6mRnpjODpyF4Rwc5UYoV1E/edit#gid=0
+  worksheet_title: UNFORMATTED VALUE
+  start_row: 2
+  default_timezone: Asia/Tokyo
+  null_string: '\N'
+  default_typecast: strict
+  value_render_option: UNFORMATTED_VALUE
+  columns:
+    - {name: _c1, type: long}
+out:
+  type: stdout

--- a/lib/embulk/input/google_spreadsheets.rb
+++ b/lib/embulk/input/google_spreadsheets.rb
@@ -108,6 +108,9 @@ module Embulk
         task['start_row']              = config.param('start_row',              :integer, default: 1)
         task['end_row']                = config.param('end_row',                :integer, default: -1)
         task['max_fetch_rows']         = config.param('max_fetch_rows',         :integer, default: 10000)
+        # FORMATTED_VALUE, UNFORMATTED_VALUE, FORMULA are available.
+        # ref. https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption
+        task['value_render_option']    = config.param('value_render_option',    :string,  default: 'FORMATTED_VALUE')
         task['null_string']            = config.param('null_string',            :string,  default: '')
         task['stop_on_invalid_record'] = config.param('stop_on_invalid_record', :bool,    default: true)
         # columns: this option supposes an array of hash has the below structure.

--- a/lib/embulk/input/google_spreadsheets/pager.rb
+++ b/lib/embulk/input/google_spreadsheets/pager.rb
@@ -79,7 +79,11 @@ module Embulk
         def empty_record?(record)
           return true unless record
           return true if record.empty?
-          record.all?{|v| v.nil? or v.empty?}
+          record.all? do |v|
+            next true if v.nil?
+            next true if v.is_a?(String) and v.empty?
+            false
+          end
         end
 
         def no_limit?

--- a/lib/embulk/input/google_spreadsheets/spreadsheets_client.rb
+++ b/lib/embulk/input/google_spreadsheets/spreadsheets_client.rb
@@ -7,11 +7,12 @@ module Embulk
 
       class SpreadsheetsClient
 
-        attr_accessor :spreadsheets_url, :worksheet_title, :auth, :pager
+        attr_accessor :spreadsheets_url, :worksheet_title, :value_render_option, :auth, :pager
 
         def initialize(task, auth:, pager:)
           @spreadsheets_url = task['spreadsheets_url']
           @worksheet_title = task['worksheet_title']
+          @value_render_option = task['value_render_option']
           @auth = auth
           @pager = pager
         end
@@ -54,8 +55,11 @@ module Embulk
 
         def worksheet_values(range)
           range = "#{worksheet_title}!#{range}"
-          logger.info { "`embulk-input-google_spreadsheets`: load data from spreadsheet: '#{spreadsheets_url}', range: '#{range}'" }
-          service.get_spreadsheet_values(spreadsheets_id, range).values
+          logger.info {
+            "`embulk-input-google_spreadsheets`: load data from spreadsheet: '#{spreadsheets_url}'," \
+            " range: '#{range}', value_render_option: '#{value_render_option}'"
+          }
+          service.get_spreadsheet_values(spreadsheets_id, range, value_render_option: value_render_option).values
         end
 
         def worksheet_each_record(&block)

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -54,6 +54,7 @@ module Embulk
           assert_equal(-1, task['end_row'])
           assert_equal(10000, task['max_fetch_rows'])
           assert_equal('', task['null_string'])
+          assert_equal('FORMATTED_VALUE', task['value_render_option'])
           assert_equal(true, task['stop_on_invalid_record'])
           assert_equal('%Y-%m-%d %H:%M:%S.%N %z', task['default_timestamp_format'])
           assert_equal('UTC', task['default_timezone'])

--- a/test/test_run_examples.rb
+++ b/test/test_run_examples.rb
@@ -120,6 +120,26 @@ module Embulk
           end
         end
       end
+
+      sub_test_case 'run unformatted value' do
+        unless File.exist?(JSON_KEYFILE_AUTHORIZED_USER)
+          puts "'#{JSON_KEYFILE_AUTHORIZED_USER}' is not found. Skip case authorized_user"
+        else
+          test 'authorized_user' do
+
+            assert_true embulk_run(File.join(EXAMPLE_ROOT, 'config_authorized_user_unformatted_value.yml'))
+          end
+        end
+
+        unless File.exist?(JSON_KEYFILE_SERVICE_ACCOUNT)
+          puts "'#{JSON_KEYFILE_SERVICE_ACCOUNT}' is not found. Skip case service_account"
+        else
+          test 'service_account' do
+
+            assert_true embulk_run(File.join(EXAMPLE_ROOT, 'config_service_account_unformatted_value.yml'))
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Sometimes, you want to load `$1` as `1`. In this case, `value_render_option` can be used.
See [the document](https://developers.google.com/sheets/api/reference/rest/v4/ValueRenderOption) to know what I want to resolve.