### PR TITLE
Loose regex of spreadsheets url

### DIFF
--- a/lib/embulk/input/google_spreadsheets/spreadsheets_url_util.rb
+++ b/lib/embulk/input/google_spreadsheets/spreadsheets_url_util.rb
@@ -14,7 +14,7 @@ module Embulk
         end
 
         def self.capture_id_regex
-          @capture_id_regex ||= %r{#{base_url}([^/]+)/.*}
+          @capture_id_regex ||= %r{#{base_url}([^/]+).*}
         end
       end
     end


### PR DESCRIPTION
- currently cannot capture URL that can opened url using browser
   - i.e,) https://docs.google.com/spreadsheets/d/${SPREADSHEET_ID}