### PR TITLE
logging when rescue Google::Apis::Error for enhance traceability

### DIFF
--- a/lib/embulk/input/google_spreadsheets.rb
+++ b/lib/embulk/input/google_spreadsheets.rb
@@ -178,6 +178,16 @@ module Embulk
 
         task_report = {}
         return task_report
+
+      rescue Google::Apis::Error => e
+        logger.error {
+          m  = "Error: #{e.class}"
+          m << ", Message: #{e.message}"        if e.message
+          m << ", StatusCode: #{e.status_code}" if e.status_code
+          m << ", Body: #{e.body}"              if e.body
+          m
+        }
+        raise e
       end
     end
   end


### PR DESCRIPTION
output log sample
```
2017-12-20 12:44:36.939 +0900 [INFO] (0001:transaction): Using local thread executor with max_threads=16 / output tasks 8 = input tasks 1 * 8
2017-12-20 12:44:36.948 +0900 [INFO] (0001:transaction): {done:  0 / 1, running: 0}

2017-12-20 12:44:38.569 +0900 [ERROR] (0016:task-0000): Error: Google::Apis::ClientError, Message: Invalid request, StatusCode: 404, Body: <!DOCTYPE html>
<html lang=en>
  <meta charset=utf-8>
  <meta name=viewport content="initial-scale=1, minimum-scale=1, width=device-width">
  <title>Error 404 (Not Found)!!1</title>
  <style>
    *{margin:0;padding:0}html,code{font:15px/22px arial,sans-serif}html{background:#fff;color:#222;padding:15px}body{margin:7% auto 0;max-width:390px;min-height:180px;padding:30px 0 15px}* > body{background:url(//www.google.com/images/errors/robot.png) 100% 5px no-repeat;padding-right:205px}p{margin:11px 0 22px;overflow:hidden}ins{color:#777;text-decoration:none}a img{border:0}@media screen and (max-width:772px){body{background:none;margin-top:0;max-width:none;padding-right:0}}#logo{background:url(//www.google.com/images/branding/googlelogo/1x/googlelogo_color_150x54dp.png) no-repeat;margin-left:-5px}@media only screen and (min-resolution:192dpi){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat 0% 0%/100% 100%;-moz-border-image:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) 0}}@media only screen and (-webkit-min-device-pixel-ratio:2){#logo{background:url(//www.google.com/images/branding/googlelogo/2x/googlelogo_color_150x54dp.png) no-repeat;-webkit-background-size:100% 100%}}#logo{display:inline-block;height:54px;width:150px}
  </style>
  <a href=//www.google.com/><span id=logo aria-label=Google></span></a>
  <p><b>404.</b> <ins>That’s an error.</ins>
  <p>The requested URL <code>/v4/spreadsheets/?includeGridData=false&amp;ranges=xxxxxxxx</code> was not found on this server.  <ins>That’s all we know.</ins>
```