### PR TITLE
Add validation for start_row in pager.rb

### DIFF
--- a/lib/embulk/input/google_spreadsheets/pager.rb
+++ b/lib/embulk/input/google_spreadsheets/pager.rb
@@ -67,6 +67,10 @@ module Embulk
 
         def max_accessible_row_num(client)
           sheets_max = client.worksheet_max_row_num
+          if start_row > sheets_max
+            raise ConfigError.new("`embulk-input-google_spreadsheets`: start_row `#{start_row}` is larger than spreadsheets max row `#{sheets_max}`")
+          end
+
           if end_row > sheets_max
             raise ConfigError.new("`embulk-input-google_spreadsheets`: end_row `#{end_row}` is larger than spreadsheets max row `#{sheets_max}`")
           end


### PR DESCRIPTION
Fixed a bug that unintended rows were retrieved when a value larger than sheets_max was specified for start_row.

### bug details
When creating a spreadsheet with one row and two columns (see screenshot) and executing the plugin with start_row: 2 specified in config.yml, get_spreadsheet_values is executed for the range of `A2:B1`.
The `A2:B1` range here is interpreted by the Google API in the same way as `A1:B1`, and `[["ID", "value"]` is obtained.

<img src="https://github.com/user-attachments/assets/e8225806-7533-48f9-b782-34474d973527" width="500" />

Similarly, if you create a spreadsheet with 3 rows and 2 columns (see screenshot) and run the plugin with start_row: 4 in config.yml, get_spreadsheet_values to the range of `A4:B3` is executed and `[["2", "second value"]]` is obtained.

<img src="https://github.com/user-attachments/assets/b505720d-84cc-4ae3-8d34-c1e1ef6b5ed6" width="500" />